### PR TITLE
Fix dubious ownership in repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN apk update && apk upgrade && \
 
 RUN pip3 install git-filter-repo
 
+# T314987: Git require the .git folder to be owned by the same user
+RUN git config --system --add safe.directory /github/workspace
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Bug: [T314987](https://phabricator.wikimedia.org/T314987)

Fix fatal: detected dubious ownership in repository at '/github/workspace'

This had caused several CI failures in https://github.com/wikimedia/mediawiki-extensions-Wikibase/actions .

> Error: fatal: detected dubious ownership in repository at '/github/workspace'
>  To add an exception for this directory, call:
>  `git config --global --add safe.directory /github/workspace`
> Reason: Recent versions of git require the .git folder to be owned
>  by the same user (see https://github.blog/2022-04-12-git-security-vulnerability-announced/ ).
> 
> Related:
> 
> - https://github.com/actions/checkout/issues/1048
> - https://github.com/espressif/github-actions/pull/36

----

Patchsets:

* patchset 1: 11a8179
* patchset 2: 60aafd5